### PR TITLE
fix: rename notifications service queue

### DIFF
--- a/azurite-init/create-queues.sh
+++ b/azurite-init/create-queues.sh
@@ -3,6 +3,7 @@
 files="./env-files/*.env"
 for f in $files
 do
+    echo "Analizing env file: [$f]"
     queues=$(cat $f | sed -nr "s/^.*=(pagopa-ecommerce-.*-queue)$/\1/p")
     for queue in $queues
         do

--- a/pagopa-notifications-service/notifications-service.env
+++ b/pagopa-notifications-service/notifications-service.env
@@ -2,8 +2,8 @@ AWS_SES_ACCESS_KEY_ID=aws_ses_access_key_id
 AWS_SES_REGION=eu-south-1
 AWS_SES_SECRET_ACCESS_KEY=aws_ses_secret_access_key
 STORAGE_CONNECTION_STRING=AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;DefaultEndpointsProtocol=http;BlobEndpoint=http://azurite:10000/devstoreaccount1;QueueEndpoint=http://azurite:10001/devstoreaccount1;TableEndpoint=http://azurite:10002/devstoreaccount1;
-RETRY_QUEUE_NAME=retry-queue
-ERROR_QUEUE_NAME=error-queue
+RETRY_QUEUE_NAME=pagopa-ecommerce-notifications-service-retry-queue
+ERROR_QUEUE_NAME=pagopa-ecommerce-notifications-service-errors-queue
 CLIENT_PAYMENT_MANAGER={"TEMPLATE_IDS":["poc-1"]}
 CLIENT_ECOMMERCE={"TEMPLATE_IDS":["poc-1"]}
 CLIENT_ECOMMERCE_TEST={"TEMPLATE_IDS":["poc-1"]}


### PR DESCRIPTION
Rename notifications-service queues to reflect the name of the infra archived ones (as done for other ecommerce modules),

This modification serves two purpose:

1. Have locally created queue reflect DEV/UAT env queue names specified on [INFRA](https://github.com/pagopa/pagopa-infra/blob/1a663905a3ca6a5bfd5f600ab0b0f307c9b4e1d2/src/domains/ecommerce-common/03_storage.tf#L72-L81)
2. With this naming convention queue are created automatically by azure-init script execution since new name reflect the script expected naming convention 